### PR TITLE
audit: report failed AX window moves

### DIFF
--- a/Sources/windowhop/AppDelegate.swift
+++ b/Sources/windowhop/AppDelegate.swift
@@ -143,7 +143,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         switch WindowMover.attemptMove(capturedWindow, to: display) {
         case .moved:
             break
-        case .noWindow, .fullscreen:
+        case .noWindow, .fullscreen, .failed:
             playError()
         }
         dismissOverlay()

--- a/Sources/windowhop/WindowMover.swift
+++ b/Sources/windowhop/WindowMover.swift
@@ -5,6 +5,7 @@ enum MoveResult {
     case moved
     case noWindow
     case fullscreen
+    case failed
 }
 
 enum WindowMover {
@@ -45,8 +46,7 @@ enum WindowMover {
     static func attemptMove(_ window: AXUIElement?, to display: DisplayInfo) -> MoveResult {
         guard let window else { return .noWindow }
         if isFullscreen(window) { return .fullscreen }
-        move(window, to: display)
-        return .moved
+        return move(window, to: display) ? .moved : .failed
     }
 
     /// Native-fullscreen windows live on their own Space and reject AX position/size
@@ -60,7 +60,7 @@ enum WindowMover {
     }
 
     /// Centers the window on the target display at ~70% of the visible frame.
-    private static func move(_ window: AXUIElement, to display: DisplayInfo) {
+    private static func move(_ window: AXUIElement, to display: DisplayInfo) -> Bool {
         let vf = display.visibleFrame
         let w = min(1600, vf.width * 0.72)
         let h = min(1000, vf.height * 0.78)
@@ -70,14 +70,15 @@ enum WindowMover {
         var origin = CGPoint(x: x, y: y)
         var size = CGSize(width: w, height: h)
         guard let posValue = AXValueCreate(.cgPoint, &origin),
-              let sizeValue = AXValueCreate(.cgSize, &size) else { return }
+              let sizeValue = AXValueCreate(.cgSize, &size) else { return false }
 
         // Set position first (gets the window onto the new display),
         // then size, then position again — some apps clamp size against the
         // *source* display's bounds on the first call, producing a half-placed window.
-        AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posValue)
-        AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
-        AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posValue)
+        let setPositionStart = AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posValue)
+        let setSize = AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
+        let setPositionEnd = AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, posValue)
+        return setPositionStart == .success && setSize == .success && setPositionEnd == .success
     }
 
     @discardableResult


### PR DESCRIPTION
## Audit Fixes (Batch 1)


Closes #1

## Root Cause Analysis
Issue #1
Root cause: `attemptMove` returned `.moved` without checking AX write results.
Fix: `move(_:to:)` now returns true only when all three AX writes succeed, and `attemptMove` maps failures to `.failed` so commit logic can play error audio.
Risk: Apps that partially apply AX writes may now produce an audible failure instead of silent success.

## Changes
- Added `MoveResult.failed`.
- Updated `WindowMover.attemptMove` to return `.failed` when AX writes fail.
- Updated `WindowMover.move` to return success from AX attribute writes.
- Updated `AppDelegate.commit(display:)` to play error audio on `.failed`.

## Test plan
- `swift build -c release`
- Attempt hop on a non-movable window and verify the Tink error sound plays.