### PR TITLE
audit: remove deprecated codesign deep flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ cp "${ICNS_PATH}" "${APP_BUNDLE}/Contents/Resources/AppIcon.icns"
 rm -rf "${ICON_WORK}"
 
 echo "→ ad-hoc codesign"
-codesign --force --deep --sign - "${APP_BUNDLE}"
+codesign --force --sign - "${APP_BUNDLE}"
 
 echo
 echo "✓ built ${PWD}/${APP_BUNDLE}"


### PR DESCRIPTION
## Audit Fixes (Batch 2)


Closes #2

## Root Cause Analysis
Issue #2
Root cause: `build.sh` used deprecated `codesign --deep` despite the app bundle currently being flat.
Fix: Removed `--deep` so ad-hoc signing uses the current recommended top-level invocation.
Risk: If nested bundles are added later, explicit inner-first signing steps will be required.

## Changes
- Updated `build.sh` ad-hoc codesign command to remove `--deep`.

## Test plan
- `swift build -c release`
- `./build.sh`
- `codesign -dvvv WindowHop.app`